### PR TITLE
Set upstream metadata fields: Repository, Repository-Browse.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+cwm (7.1-2) UNRELEASED; urgency=medium
+
+  * Set upstream metadata fields: Repository, Repository-Browse.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Tue, 06 Sep 2022 17:57:37 -0000
+
 cwm (7.1-1) unstable; urgency=medium
 
   * Import upstream 7.1 sources

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,3 @@
+---
+Repository: https://github.com/leahneukirchen/cwm.git
+Repository-Browse: https://github.com/leahneukirchen/cwm


### PR DESCRIPTION

Set upstream metadata fields: Repository, Repository-Browse. ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing), [upstream-metadata-missing-repository](https://lintian.debian.org/tags/upstream-metadata-missing-repository))

These changes have no impact on the [binary debdiff](https://janitor.debian.net/api/run/d8e78eeb-e388-4320-844e-45d2b2fcd123/debdiff?filter_boring=1).

You can also view the [diffoscope diff](https://janitor.debian.net/api/run/d8e78eeb-e388-4320-844e-45d2b2fcd123/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/d8e78eeb-e388-4320-844e-45d2b2fcd123/diffoscope)).

This merge proposal was created by the [Janitor bot](https://janitor.debian.net/lintian-fixes), and it will automatically rebase or close this proposal as appropriate when the target branch changes. Any comments you leave here will be read by the Janitor's maintainers.

Build and test logs for this branch can be found at https://janitor.debian.net/lintian-fixes/pkg/cwm/d8e78eeb-e388-4320-844e-45d2b2fcd123.